### PR TITLE
support 1.0 confidence

### DIFF
--- a/src/pyransac/degensac/rtools.c
+++ b/src/pyransac/degensac/rtools.c
@@ -1,3 +1,4 @@
+#include <float.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -218,7 +219,7 @@ int nsamples(int ninl, int ptNum, int samsiz, double conf)
   else
     {
       b = log(1-conf) / log(a);
-      if (b > MAX_SAMPLES)
+      if ((b != b) || (b < -FLT_MAX || b > FLT_MAX) || (b > MAX_SAMPLES))
         return MAX_SAMPLES; else
         return (int) ceil(b);
     }


### PR DESCRIPTION
Add support for confidence value 1.0.
If confidence value is 1.o, it will cause log fuction to produce INF values.
So if value `b` is INF then we can return the hard coded MAX_SAMPLES.

1.0 Probably would be helpful when you want to make the ransac run for a centain number of iteration instead of early termination.